### PR TITLE
Trigger flame effect according to Morse Code

### DIFF
--- a/audiomixserver.cc
+++ b/audiomixserver.cc
@@ -642,6 +642,15 @@ struct context {
       std::ofstream laser_gpio{option.as<std::string>()};
       laser_gpio << (laser_level ^ vm["gpio_off_value"].as<int>());
     }
+    
+    auto flame_effect_option = vm["trigger_flame_effect"];
+    if (!option.empty()) {
+       if (laser_level) {
+           system("curl http://192.168.1.20/fire &");
+       } else {
+           system("curl http://192.168.1.20/off &");
+       }
+    }
   }
 
   sequence_t start_sequence(decltype(sequence_to_status)::iterator const &i) {


### PR DESCRIPTION
Nope this hasn't been tested -- I actually have no idea what I'm doing here and am probably missing like 20 `#includes`, but the proof-of-concept should be pretty clear here.

Also, would probably make more sense to make the param `vm["flame_effect_server"]` or something like that to construct the target URLs.